### PR TITLE
Added supported for roof type objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ We have implemented a few objects as a basis and will expand this to include oth
 
 **CSG:** 3D solids made using boolean operations of other solids. For example the union of two spheres. Each CSG has an operand and two children, these children are themselves 3D objects which can be primitives or other CSG's (1 parameter + childrens' parameter count) _note:_ CSG will turn all faces into triangular meshes, and requires pymesh and boolean engines to be installed.
 
+### Roof Types ###
+Each roof type centers the bottom of the roof at the origin.  The optional building height parameter controls how far down to extrude the bottom of the roof, if at all.  The building height paramater is included in the parameter counts below
+
+**Flat roof:** defined by a roof length, and roof width (3 parameters)
+
+**Shed roof:** defined by a roof height, roof length, and roof width (4 paramters)
+
+**Gable roof:** defined by a roof height, roof length, and roof width (4 paramters)
+
+**Gambrel roof:** defined by two roof height parameters, roof length, and two roof width parameters.  The roof height parameters control the height at each "step" of the roof, whereas the roof width parameters control the width at each "step".  The final height of the roof is the sum of the two roof height parameters (6 paramters)
+
+**Hipped roof:** defined by a roof height, two roof length parameters, and roof width.  The second roof length parameter sets the length at the roof peak (5 paramters)
+
+**Mansard roof:** defined by two roof height parameters, three roof length parameters, and two roof width parameters. The roof height, length, and width parameters control the height, length, and width respectively at each "step" of the roof, where the last length parameter sets the length at the roof peak.  The final height of the roof is the sum of the two roof height parameters (8 parameters)
+
 ## Scene meshing ##
 We have provided a sample program and sample data to reconstruct the geometry encoded in this format. This program reads in the sample JSON file and creates a directory with series of .obj files for loading into a variety of 3D viewers/rendering programs. To execute the sample program python 3 along with numpy and pymesh are needed. Once all the dependencies are installed simply execute
 

--- a/json2obj.py
+++ b/json2obj.py
@@ -1,5 +1,6 @@
 import numpy as np
 import primitiveMeshGen
+import roofGen
 import json
 import os
 import argparse
@@ -74,6 +75,18 @@ def parseObject(obj,temppath=None):
     fv = parsePlanarRegion(obj)
   elif objtype == 'csg':
     fv = parseCSG(obj,temppath=temppath)
+  elif objtype == 'flat':
+    fv = parseFlat(obj)
+  elif objtype == 'shed':
+    fv = parseShed(obj)
+  elif objtype == 'gable':
+    fv = parseGable(obj)
+  elif objtype == 'gambrel':
+    fv = parseGambrel(obj)
+  elif objtype == 'hipped':
+    fv = parseHipped(obj)
+  elif objtype == 'mansard':
+    fv = parseMansard(obj)
   # ensure numpy array
   fv['vertices'] = np.array(fv['vertices'])
 
@@ -112,6 +125,60 @@ def parseTransform(trans):
   else:
     raise ValueError(transtype + ' is not a valid transformation')
   return affMat
+
+# parse flat
+def parseFlat(data):
+  v, f = roofGen.flatGen(data['roof_length'],
+                         data['roof_width'],
+                         data['building_height'])
+  return {'vertices': v, 'faces': f}
+
+# parse shed
+def parseShed(data):
+  v, f = roofGen.shedGen(data['roof_height'],
+                         data['roof_length'],
+                         data['roof_width'],
+                         data.get('building_height', 0))
+  return {'vertices': v, 'faces': f}
+
+# parse gable
+def parseGable(data):
+  v, f = roofGen.gableGen(data['roof_height'],
+                          data['roof_length'],
+                          data['roof_width'],
+                          data.get('building_height', 0))
+  return {'vertices': v, 'faces': f}
+
+# parse gambrel
+def parseGambrel(data):
+  v, f = roofGen.gambrelGen(data['roof_height_1'],
+                            data['roof_height_2'],
+                            data['roof_length'],
+                            data['roof_width_1'],
+                            data['roof_width_2'],
+                            data.get('building_height', 0))
+  return {'vertices': v, 'faces': f}
+
+# parse hipped
+def parseHipped(data):
+  v, f = roofGen.hippedGen(data['roof_height'],
+                           data['roof_length_1'],
+                           data['roof_length_2'],
+                           data['roof_width'],
+                           data.get('building_height', 0))
+  return {'vertices': v, 'faces': f}
+
+# parse mansard
+def parseMansard(data):
+  v, f = roofGen.mansardGen(data['roof_height_1'],
+                            data['roof_height_2'],
+                            data['roof_length_1'],
+                            data['roof_length_2'],
+                            data['roof_length_3'],
+                            data['roof_width_1'],
+                            data['roof_width_2'],
+                            data.get('building_height', 0))
+  return {'vertices': v, 'faces': f}
 
 # parse sphere
 def parseSphere(data):

--- a/roofGen.py
+++ b/roofGen.py
@@ -1,0 +1,256 @@
+# For all roof / building generation functions, the lowest roof plane
+# is centered at the origin.  The building portion of the object is
+# extruded from this lowest roof plane to a length of
+# "building_height".
+
+
+# Generate flat roof building
+def flatGen(roof_length,
+            roof_width,
+            building_height):
+    xinterval = roof_length / 2
+    yinterval = roof_width / 2
+
+    vertices = [[-xinterval, yinterval, 0],
+                [-xinterval, -yinterval, 0],
+                [xinterval, -yinterval, 0],
+                [xinterval, yinterval, 0],
+                [-xinterval, yinterval, -building_height],
+                [-xinterval, -yinterval, -building_height],
+                [xinterval, -yinterval, -building_height],
+                [xinterval, yinterval, -building_height]]
+
+    faces = [[0, 1, 2, 3],
+             [4, 7, 6, 5],
+             [0, 4, 5, 1],
+             [1, 5, 6, 2],
+             [2, 6, 7, 3],
+             [3, 7, 4, 0]]
+
+    return vertices, faces
+
+
+# Generate shed roof / building
+def shedGen(roof_height,
+            roof_length,
+            roof_width,
+            building_height):
+    xinterval = roof_length / 2
+    yinterval = roof_width / 2
+
+    vertices = [[-xinterval, yinterval, 0],
+                [-xinterval, -yinterval, roof_height],
+                [xinterval, -yinterval, roof_height],
+                [xinterval, yinterval, 0]]
+
+    if building_height > 0:
+        vertices.extend([[-xinterval, yinterval, -building_height],
+                         [-xinterval, -yinterval, -building_height],
+                         [xinterval, -yinterval, -building_height],
+                         [xinterval, yinterval, -building_height]])
+
+        faces = [[0, 1, 2, 3],
+                 [4, 7, 6, 5],
+                 [0, 4, 5, 1],
+                 [1, 5, 6, 2],
+                 [2, 6, 7, 3],
+                 [3, 7, 4, 0]]
+    else:
+        vertices.extend([[-xinterval, -yinterval, 0],
+                         [xinterval, -yinterval, 0]])
+
+        faces = [[0, 1, 2, 3],
+                 [0, 4, 5, 3],
+                 [0, 1, 4],
+                 [2, 3, 5],
+                 [1, 2, 5, 4]]
+
+    return vertices, faces
+
+
+# Generate gable roof / building
+def gableGen(roof_height,
+             roof_length,
+             roof_width,
+             building_height):
+    xinterval = roof_length / 2
+    yinterval = roof_width / 2
+
+    vertices = [[-xinterval, yinterval, 0],
+                [-xinterval, 0, roof_height],
+                [-xinterval, -yinterval, 0],
+                [xinterval, -yinterval, 0],
+                [xinterval, 0, roof_height],
+                [xinterval, yinterval, 0]]
+
+    if building_height > 0:
+        vertices.extend([[-xinterval, yinterval, -building_height],
+                         [-xinterval, -yinterval, -building_height],
+                         [xinterval, -yinterval, -building_height],
+                         [xinterval, yinterval, -building_height]])
+
+        faces = [[0, 1, 4, 5],
+                 [1, 2, 3, 4],
+                 [0, 6, 7, 2, 1],
+                 [2, 7, 8, 3],
+                 [3, 8, 9, 5, 4],
+                 [5, 9, 6, 0],
+                 [6, 9, 8, 7]]
+    else:
+        faces = [[0, 1, 4, 5],
+                 [1, 2, 3, 4],
+                 [0, 1, 2],
+                 [3, 4, 5],
+                 [0, 2, 3, 5]]
+
+    return vertices, faces
+
+
+# Generate gambrel roof / building
+def gambrelGen(roof_height_1,
+               roof_height_2,
+               roof_length,
+               roof_width_1,
+               roof_width_2,
+               building_height):
+    xinterval = roof_length / 2
+    yinterval_1 = roof_width_1 / 2
+    yinterval_2 = roof_width_2 / 2
+
+    vertices = [[-xinterval, yinterval_1, 0],
+                [-xinterval, yinterval_2, roof_height_1],
+                [-xinterval, 0, roof_height_1 + roof_height_2],
+                [-xinterval, -yinterval_2, roof_height_1],
+                [-xinterval, -yinterval_1, 0],
+                [xinterval, -yinterval_1, 0],
+                [xinterval, -yinterval_2, roof_height_1],
+                [xinterval, 0, roof_height_1 + roof_height_2],
+                [xinterval, yinterval_2, roof_height_1],
+                [xinterval, yinterval_1, 0]]
+
+    if building_height > 0:
+        vertices.extend([[-xinterval, yinterval_1, -building_height],
+                         [-xinterval, -yinterval_1, -building_height],
+                         [xinterval, -yinterval_1, -building_height],
+                         [xinterval, yinterval_1, -building_height]])
+
+        faces = [[0, 1, 8, 9],
+                 [1, 2, 7, 8],
+                 [2, 3, 6, 7],
+                 [3, 4, 5, 6],
+                 [0, 9, 13, 10],
+                 [10, 13, 12, 11],
+                 [11, 12, 5, 4],
+                 [0, 1, 2, 3, 4, 11, 10],
+                 [5, 6, 7, 8, 9, 13, 12]]
+    else:
+        faces = [[0, 1, 8, 9],
+                 [1, 2, 7, 8],
+                 [2, 3, 6, 7],
+                 [3, 4, 5, 6],
+                 [0, 1, 2, 3, 4],
+                 [5, 6, 7, 8, 9]]
+
+    return vertices, faces
+
+
+# Generate hipped roof / building
+def hippedGen(roof_height,
+              roof_length_1,
+              roof_length_2,
+              roof_width,
+              building_height):
+
+    xinterval_1 = roof_length_1 / 2
+    xinterval_2 = roof_length_2 / 2
+    yinterval = roof_width / 2
+
+    vertices = [[-xinterval_1, yinterval, 0],
+                [-xinterval_2, 0, roof_height],
+                [-xinterval_1, -yinterval, 0],
+                [xinterval_1, -yinterval, 0],
+                [xinterval_2, 0, roof_height],
+                [xinterval_1, yinterval, 0]]
+
+    if building_height > 0:
+        vertices.extend([[-xinterval_1, yinterval, -building_height],
+                         [-xinterval_1, -yinterval, -building_height],
+                         [xinterval_1, -yinterval, -building_height],
+                         [xinterval_1, yinterval, -building_height]])
+
+        faces = [[0, 1, 4, 5],
+                 [1, 2, 3, 4],
+                 [0, 1, 2],
+                 [2, 7, 8, 3],
+                 [3, 4, 5],
+                 [5, 9, 6, 0],
+                 [6, 9, 8, 7],
+                 [0, 2, 7, 6],
+                 [3, 5, 9, 8]]
+    else:
+        faces = [[0, 1, 4, 5],
+                 [1, 2, 3, 4],
+                 [0, 1, 2],
+                 [3, 4, 5],
+                 [0, 2, 3, 5]]
+
+    return vertices, faces
+
+
+# Generate mansard roof / building
+def mansardGen(roof_height_1,
+               roof_height_2,
+               roof_length_1,
+               roof_length_2,
+               roof_length_3,
+               roof_width_1,
+               roof_width_2,
+               building_height):
+    xinterval_1 = roof_length_1 / 2
+    xinterval_2 = roof_length_2 / 2
+    xinterval_3 = roof_length_3 / 2
+    yinterval_1 = roof_width_1 / 2
+    yinterval_2 = roof_width_2 / 2
+
+    vertices = [[-xinterval_1, yinterval_1, 0],
+                [-xinterval_2, yinterval_2, roof_height_1],
+                [-xinterval_3, 0, roof_height_1 + roof_height_2],
+                [-xinterval_2, -yinterval_2, roof_height_1],
+                [-xinterval_1, -yinterval_1, 0],
+                [xinterval_1, -yinterval_1, 0],
+                [xinterval_2, -yinterval_2, roof_height_1],
+                [xinterval_3, 0, roof_height_1 + roof_height_2],
+                [xinterval_2, yinterval_2, roof_height_1],
+                [xinterval_1, yinterval_1, 0]]
+
+    if building_height > 0:
+        vertices.extend([[-xinterval_1, yinterval_1, -building_height],
+                         [-xinterval_1, -yinterval_1, -building_height],
+                         [xinterval_1, -yinterval_1, -building_height],
+                         [xinterval_1, yinterval_1, -building_height]])
+
+        faces = [[0, 1, 8, 9],
+                 [1, 2, 7, 8],
+                 [2, 3, 6, 7],
+                 [3, 4, 5, 6],
+                 [0, 9, 13, 10],
+                 [10, 13, 12, 11],
+                 [11, 12, 5, 4],
+                 [1, 2, 3],
+                 [0, 1, 3, 4],
+                 [0, 4, 11, 10],
+                 [6, 7, 8],
+                 [5, 6, 8, 9],
+                 [5, 9, 13, 12]]
+    else:
+        faces = [[0, 1, 8, 9],
+                 [1, 2, 7, 8],
+                 [2, 3, 6, 7],
+                 [3, 4, 5, 6],
+                 [1, 2, 3],
+                 [0, 1, 3, 4],
+                 [6, 7, 8],
+                 [5, 6, 8, 9],
+                 [0, 4, 5, 9]]
+
+    return vertices, faces


### PR DESCRIPTION
Added support for flat, shed, gabled, gambrel, hipped, and mansard
roof type objects.

These additions largely follow the conventions laid out in the "Geometric Primitives Library" slides, however the shed type roof is parameterized with a roof height parameter instead of a theta.  The idea here is to keep the parameters as consistent as possible between the different roof types.